### PR TITLE
bugfix remainingfreetime calculation

### DIFF
--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Database/Tablespace.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Database/Tablespace.pm
@@ -475,7 +475,7 @@ sub init {
         ($self->{bytes} - $self->{bytes_free}) / $self->{bytes_max} * 100;
     $self->{usage_history} = $self->load_state( %params ) || [];
     my $now = time;
-    my $lookback = ($params{lookback} || 30) * 24 * 3600;
+    my $horizont = (($params{lookback} || 30) + 1 ) * 24 * 3600;
     #$lookback = 91 * 24 * 3600;
     if (scalar(@{$self->{usage_history}})) {
       $self->trace(sprintf "loaded %d data sets from     %s - %s", 
@@ -484,7 +484,7 @@ sub init {
           scalar localtime($now));
       # only data sets with valid usage. only newer than 91 days
       $self->{usage_history} = 
-          [ grep { defined $_->[1] && ($now - $_->[0]) < $lookback } @{$self->{usage_history}} ];
+          [ grep { defined $_->[1] && ($now - $_->[0]) < $horizont } @{$self->{usage_history}} ];
       $self->trace(sprintf "trimmed to %d data sets from %s - %s", 
           scalar(@{$self->{usage_history}}),
           scalar localtime((@{$self->{usage_history}})[0]->[0]),
@@ -798,7 +798,7 @@ sub nagios {
         #    sqrt(($sumx2 - ($sumx ** 2)/$n) * ($sumy2 - ($sumy ** 2)/$n));
         $self->debug(sprintf "slope: %f  y-intersect: %f", $m, $b);
         if (abs($m) <= 0.000001) { # $m == 0 does not work even if $m is 0.000000
-          $self->add_nagios_ok("tablespace usage is constant");
+          $self->add_nagios_ok(sprintf"tablespace %s usage is constant",$self->{name});
         } elsif ($m > 0) {
           $remaining = (100 - $b) / $m;
           $self->add_nagios($self->check_thresholds($remaining, "90:", "30:"), 
@@ -809,10 +809,10 @@ sub nagios {
               $remaining,
               $self->{warningrange}, $self->{criticalrange});
         } else {
-          $self->add_nagios_ok("tablespace usage is decreasing");
+          $self->add_nagios_ok(sprintf"tablespace %s usage is decreasing",$self->{name});
         }
       } else {
-        $self->add_nagios_ok("no data available for prediction");
+        $self->add_nagios_ok(sprintf"no data available for prediction in %s",$self->{name});
       }
     } elsif ($params{mode} =~ 
         /server::database::tablespace::segment::extendspace/) {


### PR DESCRIPTION
Hallo Gerhard,
ich hatte dieser Tage eine größere Installation von Oracle Servern und habe mich bei der Abfrage der "remaining time free" immer gefragt warum nie oder ganz selten Werte kommen. Nach einigem Suchen bin ich darauf gestoßen das die Änderung des Aufbewahrungszeitraums für die Tablespace Werte dazu führt das der Vergleich in Zeile 768 fast immer 0 zurück gibt und somit keine Berechnung erfolgt auch wenn mehr als 2 Werte vorhanden sind.
Auf der Webseite gab es einen Kommentar von Conny Seifert (7.2.2011) welcher genau das Verhalten beschreibt.
Habe mich dann einfach mal hingesetzt und seinen Vorschlag eingearbeitet. Siehe da es funktioniert.
Das ganze ist mit dem Commit 5bd86a92ecbae74c9abf07d741ec2822c9ebff00 rein gekommen zur Beschleunigung der "remaining time free" Berechnung.

The remainingfreetime calculation had one problem as it only collects the
data for as many days it is looking back. In line 768 there is a compare
of available lines in cache file and line inside the timeframe. This
compare results every time with 0 before. Now we collect more data than
the given lookback time.
