### PR TITLE
Remote SYSDBA connections

### DIFF
--- a/plugins-scripts/Nagios/DBD/Oracle/Server.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server.pm
@@ -1153,11 +1153,11 @@ sub init {
         $username = '';
       }
 	  
-	  if ($self->{username} =~ /^([\w\-\._]+)@(sysdba)/) {
-		$username = $1;
+      if ($self->{username} =~ /^([\w\-\._]+)@(sysdba)/) {
+        $username = $1;
         $connecthash = { RaiseError => 0, AutoCommit => $self->{commit}, PrintError => 0,
               ora_session_mode => 2 }; # DBD::Oracle::ORA_SYSDBA	  
-	  }
+      }
 	  
       if ($self->{handle} = DBI->connect(
           $dsn,

--- a/plugins-scripts/Nagios/DBD/Oracle/Server.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server.pm
@@ -1152,6 +1152,13 @@ sub init {
         $dsn = sprintf "DBI:Oracle:";
         $username = '';
       }
+	  
+	  if ($self->{username} =~ /^([\w\-\._]+)@(sysdba)/) {
+		$username = $1;
+        $connecthash = { RaiseError => 0, AutoCommit => $self->{commit}, PrintError => 0,
+              ora_session_mode => 2 }; # DBD::Oracle::ORA_SYSDBA	  
+	  }
+	  
       if ($self->{handle} = DBI->connect(
           $dsn,
           $username,


### PR DESCRIPTION
Related to  lausser/check_oracle_health#11

Force a SYSDBA connections for any granted users with the ```@sysdba``` suffix.
Required for:
* "asm-diskgroup-usage" when ASM is the targeted instance
* "dataguard-lag" when Dataguard instance is in mounted mode with apply