### PR TITLE
Set sysdba flag when connecting as sysdba

### DIFF
--- a/plugins-scripts/Nagios/DBD/Oracle/Server.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server.pm
@@ -1186,6 +1186,9 @@ sub init {
         $username = $1;
         $connecthash = $sysdba_connecthash;
       }
+      elsif ($dsn =~ s/\s+as sysdba$//i) {
+        $connecthash = $sysdba_connecthash;
+      }
       if ($self->{handle} = DBI->connect(
           $dsn,
           $username,


### PR DESCRIPTION
When connecting via DBI, the sysdba flag will be set if the dsn ends with "as sysdba".