### PR TITLE
Fix detection of invalid domain indexes

### DIFF
--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Database.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Database.pm
@@ -126,6 +126,10 @@ sub init_invalid_objects {
           SELECT 'dba_indexes', index_type||' index '||owner||'.'||index_name||' of '||table_owner||'.'||table_name||' is '||status
           FROM dba_indexes
           WHERE status <> 'VALID' AND status <> 'N/A'
+          UNION
+          SELECT 'dba_indexes', index_type||' index '||owner||'.'||index_name||' of '||table_owner||'.'||table_name||' is domain status '||DOMIDX_STATUS||' and domain opstatus '||DOMIDX_OPSTATUS
+          FROM dba_indexes
+          WHERE status = 'VALID' AND ( DOMIDX_STATUS <> 'VALID' OR DOMIDX_OPSTATUS <> 'VALID')
       });
   # should be only USABLE
   @{$self->{invalidobjects}->{invalid_ind_partitions_list}} =


### PR DESCRIPTION
Fix detection of invalid domain indexes.
Indeed, in some cases the main status is VALID but DOMIDX_STATUS or DOMIDX_OPSTATUS could be not VALID, impacting statements on the related table (for example, fails with ORA-29861: domain index is marked LOADING/FAILED/UNUSABLE).