### PR TITLE
Add SysTimeModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ smidump.exe.stackdump
 rfc*.trc
 dev_rfc
 dev_rfc.trc
-*.pm
 plugins-scripts/check_*_health.ptkdb
+sh.exe.stackdump
+*.swp

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,53 @@
+# Building check_oracle_health
+
+## Prerequisites
+
+- `autoconf` / `automake`
+- `perl`
+- `make`
+
+## Steps
+
+```bash
+autoreconf -fi
+./configure
+make
+```
+
+The output is a single self-contained Perl script at:
+
+```
+plugins-scripts/check_oracle_health
+```
+
+## Configure options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--with-statefiles-dir` | `/var/tmp/check_oracle_health` | Directory for state files used by rate checks |
+| `--with-nagios-user` | `nagios` | User that will run the plugin |
+| `--with-nagios-group` | `nagios` | Group that will run the plugin |
+| `--with-mymodules-dir` | `/usr/local/nagios/libexec` | Directory for optional extension modules |
+| `--with-perl` | *(autodetected)* | Path to Perl interpreter |
+
+### Cross-platform builds
+
+If building on a different OS than the target (e.g. building on Arch Linux to run on OEL),
+specify the Perl path of the **target** system so the shebang line is correct:
+
+```bash
+./configure --with-perl=/usr/bin/perl
+make clean && make
+```
+
+## Install
+
+```bash
+make install
+```
+
+## Notes
+
+- Clock skew warnings from `make` during `./configure` are harmless (WSL filesystem timing).
+- This build includes PR #40 (SysTimeModel and SysWaitClass modes) and a fix for
+  ASM diskgroup usage calculation to account for NORMAL/HIGH redundancy mirror factors.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT(check_oracle_health,3.3.3.2)
+AC_INIT(check_oracle_health,3.3.3.2-lm)
 AM_INIT_AUTOMAKE([1.9 tar-pax])
 AM_MAINTAINER_MODE([disable])
 AC_CANONICAL_HOST

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -20,6 +20,8 @@ EXTRA_MODULES=\
   Nagios/DBD/Oracle/Server/Instance/Enqueue.pm \
   Nagios/DBD/Oracle/Server/Instance/Session.pm \
   Nagios/DBD/Oracle/Server/Instance/Sysstat.pm \
+  Nagios/DBD/Oracle/Server/Instance/SysTimeModel.pm \
+  Nagios/DBD/Oracle/Server/Instance/SysWaitClass.pm \
   Nagios/DBD/Oracle/Server/Instance.pm \
   Nagios/DBD/Oracle/Server/Database/User.pm \
   Nagios/DBD/Oracle/Server/Database/Dataguard.pm \

--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Database/Asm/Diskgroup.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Database/Asm/Diskgroup.pm
@@ -32,15 +32,16 @@ my %ERRORCODES=( 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' );
                   type,
                   total_mb,
                   usable_file_mb,
+                  required_mirror_free_mb,
                   offline_disks
           FROM
                   V$ASM_DISKGROUP
-  
+
     });
   
     if ($params{mode} =~ /server::database::asm::diskgroup::(usage|free|listdiskgroups)/) {
         foreach (@diskgroupresult) {
-          my ($name, $state, $type, $total_mb, $usable_file_mb, $offline_disks) = @{$_};
+          my ($name, $state, $type, $total_mb, $usable_file_mb, $required_mirror_free_mb, $offline_disks) = @{$_};
           if ($params{regexp}) {
             next if $params{selectname} && $name !~ /$params{selectname}/;
           } else {
@@ -53,6 +54,7 @@ my %ERRORCODES=( 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' );
           $thisparams{type} = lc $type;
           $thisparams{total_mb} = $total_mb;
           $thisparams{usable_file_mb} = $usable_file_mb;
+          $thisparams{required_mirror_free_mb} = $required_mirror_free_mb;
           $thisparams{offline_disks} = $offline_disks;
   
           my $diskgroup = DBD::Oracle::Server::Database::Asm::Diskgroup->new(
@@ -79,6 +81,7 @@ sub new {
     type => $params{type},
     total_mb => $params{total_mb},
     usable_file_mb => $params{usable_file_mb},
+    required_mirror_free_mb => $params{required_mirror_free_mb},
     offline_disks => $params{offline_disks},
     warningrange => $params{warningrange},
     criticalrange => $params{criticalrange},
@@ -94,17 +97,22 @@ sub init {
   $self->init_nagios();
   $self->set_local_db_thresholds(%params);
   if ($params{mode} =~ /server::database::asm::diskgroup::(usage|free)/) {
+    my $mirror_factor = ($self->{type} eq 'high') ? 3 :
+                        ($self->{type} eq 'normal') ? 2 : 1;
+    my $effective_total = ($self->{total_mb} - $self->{required_mirror_free_mb})
+                          / $mirror_factor;
+    $self->{effective_total_mb} = $effective_total;
     if ($self->{state} eq 'dismounted') {
       # $total_mb, $usable_file_mb, $offline_disks = '0'
       $self->{percent_used} = 100;
     } else {
       $self->{percent_used} =
-          ($self->{total_mb} - $self->{usable_file_mb}) / $self->{total_mb} * 100;
+          ($effective_total - $self->{usable_file_mb}) / $effective_total * 100;
     }
-    $self->{used_file_mb} = $self->{total_mb} - $self->{usable_file_mb};
+    $self->{used_file_mb} = $effective_total - $self->{usable_file_mb};
     $self->{percent_free} = 100 - $self->{percent_used};
     $self->{bytes_free} = $self->{usable_file_mb} * 1024 * 1024;
-    $self->{bytes_max} = $self->{total_mb} * 1024 * 1024;
+    $self->{bytes_max} = $effective_total * 1024 * 1024;
     $self->{bytes_used} = $self->{used_file_mb} * 1024 * 1024;
 
     my $tlen = 20;
@@ -151,12 +159,12 @@ sub nagios {
           $self->add_perfdata(sprintf "\'dg_%s_usage\'=%dMB;%d;%d;%d;%d",
               lc $self->{name},
               $self->{used_file_mb},
-              $self->{warningrange} * $self->{total_mb} / 100,
-              $self->{criticalrange} * $self->{total_mb} / 100,
-              0, $self->{total_mb});
+              $self->{warningrange} * $self->{effective_total_mb} / 100,
+              $self->{criticalrange} * $self->{effective_total_mb} / 100,
+              0, $self->{effective_total_mb});
           $self->add_perfdata(sprintf "\'dg_%s_size\'=%dMB",
               lc $self->{name},
-              $self->{total_mb});
+              $self->{effective_total_mb});
         } elsif ($params{mode} =~ /server::database::asm::diskgroup::free/) {
           if (! $params{units}) {
             $params{units} = "%";

--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Instance.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Instance.pm
@@ -40,6 +40,22 @@ sub init {
     } else {
       $self->add_nagios_critical("unable to aquire sysstats info");
     }
+  } elsif ($params{mode} =~ /server::instance::systimemodel/) {
+    DBD::Oracle::Server::Instance::SysTimeModel::init_systimemodel(%params);
+    if (my @systimemodel =
+        DBD::Oracle::Server::Instance::SysTimeModel::return_systimemodel(%params)) {
+      $self->{systimemodel} = \@systimemodel;
+    } else {
+      $self->add_nagios_critical("unable to aquire systimemodel info");
+    }
+  }  elsif ($params{mode} =~ /server::instance::syswaitclass/) {
+    DBD::Oracle::Server::Instance::SysWaitClass::init_syswaitclass(%params);
+    if (my @syswaitclass =
+        DBD::Oracle::Server::Instance::SysWaitClass::return_syswaitclass(%params)) {
+      $self->{syswaitclass} = \@syswaitclass;
+    } else {
+      $self->add_nagios_critical("unable to aquire syswaitclass info");
+    }
   } elsif ($params{mode} =~ /server::instance::event/) {
     DBD::Oracle::Server::Instance::Event::init_events(%params);
     if (my @events =
@@ -146,6 +162,32 @@ sub nagios {
     }
     if (! $self->{nagios_level} && ! $params{selectname}) {
       $self->add_nagios_ok("no wait problems");
+    }
+  } elsif ($params{mode} =~ /server::instance::systimemodel::listsystimemodel/) {
+    foreach (sort { $a->{name} cmp $b->{name} } @{$self->{systimemodel}}) {
+      printf "%10d %s\n", $_->{number}, $_->{name};
+    }
+    $self->add_nagios_ok("have fun");
+  } elsif ($params{mode} =~ /server::instance::systimemodel/) {
+    foreach (@{$self->{systimemodel}}) {
+      $_->nagios(%params);
+      $self->merge_nagios($_);
+    }
+    if (! $self->{nagios_level} && ! $params{selectname}) {
+      $self->add_nagios_ok("no time model problems");
+    }
+  } elsif ($params{mode} =~ /server::instance::syswaitclass::listsyswaitclass/) {
+    foreach (sort { $a->{name} cmp $b->{name} } @{$self->{syswaitclass}}) {
+      printf "%10d %s\n", $_->{number}, $_->{name};
+    }
+    $self->add_nagios_ok("have fun");
+  } elsif ($params{mode} =~ /server::instance::syswaitclass/) {
+    foreach (@{$self->{syswaitclass}}) {
+      $_->nagios(%params);
+      $self->merge_nagios($_);
+    }
+    if (! $self->{nagios_level} && ! $params{selectname}) {
+      $self->add_nagios_ok("no wait class problems");
     }
   } elsif ($params{mode} =~ /server::instance::enqueue::listenqueues/) {
     foreach (sort { $a->{name} cmp $b->{name} } @{$self->{enqueues}}) {

--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Instance/SysTimeModel.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Instance/SysTimeModel.pm
@@ -1,0 +1,111 @@
+package DBD::Oracle::Server::Instance::SysTimeModel;
+
+use strict;
+
+our @ISA = qw(DBD::Oracle::Server::Instance);
+
+my %ERRORS=( OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 );
+my %ERRORCODES=( 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' );
+
+{
+  my @systimemodel = ();
+  my $initerrors = undef;
+
+  sub add_systimemodel {
+    push(@systimemodel, shift);
+  }
+
+  sub return_systimemodel {
+    return reverse
+        sort { $a->{name} cmp $b->{name} } @systimemodel;
+  }
+
+  sub init_systimemodel {
+    my %params = @_;
+    my $num_systimemodel = 0;
+    my %longnames = ();
+    if (($params{mode} =~ /server::instance::systimemodel::rate/) ||
+        ($params{mode} =~ /server::instance::systimemodel::listsystimemodel/)) {
+      my @systimemodelresults = $params{handle}->fetchall_array(q{
+          SELECT stat_id, stat_name, value FROM v$sys_time_model
+      });
+      foreach (@systimemodelresults) {
+        my ($number, $name, $value) = @{$_};
+        if ($params{regexp}) {
+          next if $params{selectname} && $name !~ /$params{selectname}/;
+        } else {
+          next if ($params{selectname} && (
+              ($params{selectname} !~ /^\d+$/ && (lc $params{selectname} ne lc $name)) ||
+              ($params{selectname} =~ /^\d+$/ && ($params{selectname} != $number))));
+        }
+        my %thisparams = %params;
+        $thisparams{name} = $name;
+        $thisparams{number} = $number;
+        $thisparams{value} = $value;
+
+        my $systimemodel = DBD::Oracle::Server::Instance::SysTimeModel->new(
+            %thisparams);
+        add_systimemodel($systimemodel);
+        $num_systimemodel++;
+      }
+      if (! $num_systimemodel) {
+        $initerrors = 1;
+        return undef;
+      }
+    }
+  }
+
+}
+
+sub new {
+  my $class = shift;
+  my %params = @_;
+  my $self = {
+    handle => $params{handle},
+    name => $params{name},
+    number => $params{number},
+    
+    value => $params{value},
+    rate => $params{rate},
+    count => $params{count},
+    warningrange => $params{warningrange},
+    criticalrange => $params{criticalrange},
+  };
+  #$self->{name} =~ s/^\s+//;
+  #$self->{name} =~ s/\s+$//;
+  bless $self, $class;
+  $self->init(%params);
+  return $self;
+}
+
+sub init {
+  my $self = shift;
+  my %params = @_;
+  $self->init_nagios();
+  if ($params{mode} =~ /server::instance::systimemodel::rate/) {
+    $params{differenciator} = lc $self->{name};
+    $self->valdiff(\%params, qw(value));
+    $self->{rate} = $self->{delta_value} / $self->{delta_timestamp};
+  }
+}
+
+sub nagios {
+  my $self = shift;
+  my %params = @_;
+  if (! $self->{nagios_level}) {
+    if ($params{mode} =~ /server::instance::systimemodel::rate/) {
+      $self->add_nagios(
+          $self->check_thresholds($self->{rate}, "10", "100"),
+          sprintf "%.6f %s/sec", $self->{rate}, $self->{name});
+      $self->add_perfdata(sprintf "'%s_per_sec'=%.6f;%s;%s",
+          $self->{name},
+          $self->{rate},
+          $self->{warningrange}, $self->{criticalrange});
+      $self->add_perfdata(sprintf "'%s'=%u",
+          $self->{name},
+          $self->{delta_value});
+    }
+  }
+}
+
+1;

--- a/plugins-scripts/Nagios/DBD/Oracle/Server/Instance/SysWaitClass.pm
+++ b/plugins-scripts/Nagios/DBD/Oracle/Server/Instance/SysWaitClass.pm
@@ -1,0 +1,133 @@
+package DBD::Oracle::Server::Instance::SysWaitClass;
+
+use strict;
+
+our @ISA = qw(DBD::Oracle::Server::Instance);
+
+my %ERRORS=( OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 );
+my %ERRORCODES=( 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' );
+
+{
+  my @syswaitclass = ();
+  my $initerrors = undef;
+
+  sub add_syswaitclass {
+    push(@syswaitclass, shift);
+  }
+
+  sub return_syswaitclass {
+    return reverse
+        sort { $a->{name} cmp $b->{name} } @syswaitclass;
+  }
+
+  sub init_syswaitclass {
+    my %params = @_;
+    my $num_syswaitclass = 0;
+    my %longnames = ();
+    if (($params{mode} =~ /server::instance::syswaitclass::rate/) ||
+        ($params{mode} =~ /server::instance::syswaitclass::listsyswaitclass/)) {
+      my @syswaitclassresults = $params{handle}->fetchall_array(q{
+          SELECT WAIT_CLASS_ID, WAIT_CLASS, TOTAL_WAITS, TOTAL_WAITS_FG, TIME_WAITED, TIME_WAITED_FG FROM v$system_wait_class
+      });
+      foreach (@syswaitclassresults) {
+        my ($number, $name, $total_waits, $total_waits_fg, $time_waited, $time_waited_fg) = @{$_};
+        if ($params{regexp}) {
+          next if $params{selectname} && $name !~ /$params{selectname}/;
+        } else {
+          next if ($params{selectname} && (
+              ($params{selectname} !~ /^\d+$/ && (lc $params{selectname} ne lc $name)) ||
+              ($params{selectname} =~ /^\d+$/ && ($params{selectname} != $number))));
+        }
+        my %thisparams = %params;
+        $thisparams{name} = $name;
+        $thisparams{number} = $number;
+        $thisparams{total_waits} = $total_waits;
+        $thisparams{total_waits_fg} = $total_waits_fg;
+        $thisparams{time_waited} = $time_waited;
+        $thisparams{time_waited_fg} = $time_waited_fg;
+
+        my $syswaitclass = DBD::Oracle::Server::Instance::SysWaitClass->new(
+            %thisparams);
+        add_syswaitclass($syswaitclass);
+        $num_syswaitclass++;
+      }
+      if (! $num_syswaitclass) {
+        $initerrors = 1;
+        return undef;
+      }
+    }
+  }
+
+}
+
+sub new {
+  my $class = shift;
+  my %params = @_;
+  my $self = {
+    handle => $params{handle},
+    name => $params{name},
+    number => $params{number},
+    total_waits => $params{total_waits},
+    total_waits_fg => $params{total_waits_fg},
+    time_waited => $params{time_waited},
+    time_waited_fg => $params{time_waited_fg},
+    rate => $params{rate},
+    count => $params{count},
+    warningrange => $params{warningrange},
+    criticalrange => $params{criticalrange},
+  };
+  #$self->{name} =~ s/^\s+//;
+  #$self->{name} =~ s/\s+$//;
+  bless $self, $class;
+  $self->init(%params);
+  return $self;
+}
+
+sub init {
+  my $self = shift;
+  my %params = @_;
+  $self->init_nagios();
+  if ($params{mode} =~ /server::instance::syswaitclass::rate/) {
+    $params{differenciator} = lc $self->{name};
+    $self->valdiff(\%params, qw(time_waited));
+    my $timedelta=$self->{delta_timestamp};
+    $self->{time_waited_rate} = $self->{delta_time_waited} / $timedelta;
+    $self->valdiff(\%params, qw(time_waited_fg));
+    $self->{time_waited_fg_rate} = $self->{delta_time_waited_fg} / $timedelta;
+    $self->valdiff(\%params, qw(total_waits));
+    $self->{total_waits_rate} = $self->{delta_total_waits} / $timedelta;
+    $self->valdiff(\%params, qw(total_waits_fg));
+    $self->{total_waits_fg_rate} = $self->{delta_total_waits_fg} / $timedelta;
+
+  }
+}
+
+sub nagios {
+  my $self = shift;
+  my %params = @_;
+  if (! $self->{nagios_level}) {
+    if ($params{mode} =~ /server::instance::syswaitclass::rate/) {
+      $self->add_nagios(
+          $self->check_thresholds($self->{time_waited_rate}, "10", "100"),
+          sprintf "%.6f %s/sec", $self->{time_waited_rate}, $self->{name});
+      $self->add_perfdata(sprintf "'%s_%s_per_sec'=%.6f;%s;%s",
+          $self->{name},'time_waited',
+          $self->{time_waited_rate},
+          $self->{warningrange}, $self->{criticalrange});
+      $self->add_perfdata(sprintf "'%s_%s_per_sec'=%.6f;%s;%s",
+          $self->{name},'time_waited_fg',
+          $self->{time_waited_fg_rate},
+          $self->{warningrange}, $self->{criticalrange});
+      $self->add_perfdata(sprintf "'%s_%s_per_sec'=%.6f;%s;%s",
+          $self->{name},'total_waits',
+          $self->{total_waits_rate},
+          $self->{warningrange}, $self->{criticalrange});
+      $self->add_perfdata(sprintf "'%s_%s_per_sec'=%.6f;%s;%s",
+          $self->{name},'total_waits_fg',
+          $self->{total_waits_fg_rate},
+          $self->{warningrange}, $self->{criticalrange});
+    }
+  }
+}
+
+1;

--- a/plugins-scripts/check_oracle_health.pl
+++ b/plugins-scripts/check_oracle_health.pl
@@ -246,6 +246,19 @@ my @modes = (
   ['server::instance::sysstat::listsysstats',
       'list-sysstats', undef,
       'convenience function which lists all statistics from v$sysstat' ],
+  ['server::instance::systimemodel::rate',
+      'systimemodel', undef,
+      'change of systimemodel values over time' ],
+  ['server::instance::systimemodel::listsystimemodel',
+      'list-systimemodel', undef,
+      'convenience function which lists all statistics from v$sys_time_model' ],
+  ['server::instance::syswaitclass::rate',
+      'syswaitclass', undef,
+      'change of syswaitclass values over time' ],
+  ['server::instance::syswaitclass::listsyswaitclass',
+      'list-syswaitclass', undef,
+      'convenience function which lists all statistics from v$syswaitclass' ],
+
 );
 
 sub print_usage () {


### PR DESCRIPTION
I added a new Instance::SysTimeModel package in order to retrieve v$sys_time_model data, which is really useful for drawing database activity. As you can see, I'm pretty newbie on perl and I needed three commits :(, even though this is a clone of your sysstats package 
